### PR TITLE
Update CI + Document minimal C++ 20 version

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -61,7 +61,7 @@ jobs:
           - description: "Macos Appleclang"
             os: macos-latest
             toolchain: "cmake/appleclang-toolchain.cmake"
-        cpp_version: [17, 20, 23, 26]
+        cpp_version: [20, 23, 26]
         cmake_args:
           - description: "Default"
           - description: "TSan"
@@ -73,7 +73,7 @@ jobs:
               description: "Ubuntu GCC"
               os: ubuntu-latest
               toolchain: "cmake/gnu-toolchain.cmake"
-            cpp_version: 17
+            cpp_version: 20
             cmake_args:
               description: "Werror"
               args: "-DCMAKE_CXX_FLAGS='-Werror=all -Werror=extra'"
@@ -81,7 +81,7 @@ jobs:
               description: "Ubuntu GCC"
               os: ubuntu-latest
               toolchain: "cmake/gnu-toolchain.cmake"
-            cpp_version: 17
+            cpp_version: 20
             cmake_args:
               description: "Dynamic"
               args: "-DBUILD_SHARED_LIBS=on"
@@ -162,7 +162,7 @@ jobs:
           ninja --version
       - name: Configure CMake
         run: |
-          cmake -B build -S . -DCMAKE_CXX_STANDARD=17 ${{ matrix.args.arg }}
+          cmake -B build -S . -DCMAKE_CXX_STANDARD=20 ${{ matrix.args.arg }}
         env:
           CMAKE_GENERATOR: "Ninja Multi-Config"
       - name: Build Release

--- a/README.md
+++ b/README.md
@@ -22,7 +22,9 @@ within storage managed by `std::optional`, `std::list`, et cetera.
 
 ### Dependencies
 
-This project has no C or C++ dependencies.
+This project has no C or C++ dependencies,
+however,
+it requires **C++20** or above to compile.
 
 Build-time dependencies:
 


### PR DESCRIPTION
This PR updates the CI script so C++17 based tests are not run.

It also adds a note in README that this project requires C++20 or above.