### PR TITLE
Update CODEOWNERS: remove deprecated group

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -20,4 +20,4 @@
 # .pre-commit-config.yaml @wusatosi # Add other project owners here
 # .markdownlint.yaml @wusatosi # Add other project owners here
 
-*  @bretbrownjr @camio @dietmarkuehl @neatudarius @steve-downey @wusatosi @bemanproject/core-reviewers
+*  @bretbrownjr @camio @dietmarkuehl @steve-downey @wusatosi


### PR DESCRIPTION
Update CODEOWNERS: remove deprecated group https://github.com/bemanproject/beman/blob/main/docs/BEMAN_STANDARD.md#repositorycodeowners